### PR TITLE
feat(api-server, openapi, website): implement login UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ There is also `local-dev-reverse-proxy` — an Dockerized NGINX reverse proxy se
 
 ### TL;DR
 
+#### Postgres Prerequisites
+
+As a prerequisite, you need to:
+
+- Run a local `postgres` server, eg `docker run --name some-postgres -e POSTGRES_PASSWORD=some_password -p 5432:5432 postgres`
+- Create a `api-server/.env` with connection info, including that password
+- Run migrations on the server with `knex`.
+
+For these steps, see `api-server/README.md` for specific instructions.
+
+#### Running the application locally
+
 To run everything locally, run these on separate terminal tabs:
 
 1. `cd api-server; npm run dev`

--- a/api-server/src/app.ts
+++ b/api-server/src/app.ts
@@ -6,7 +6,7 @@ import encounterCardRouter from './routes/encounter-cards'
 import expeditionsRouter from './routes/expeditions'
 import gameStateRouter from './routes/game-state'
 import healthRouter from './routes/health'
-import loginRouter from './routes/login'
+import userRouter from './routes/user'
 import rootRouter from './routes/root'
 if (process.env.NODE_ENV !== 'production') {
   console.log('Loading .env file into "process.env"')
@@ -38,7 +38,7 @@ app.use('/api/drifter-cards', drifterCardRouter)
 app.use('/api/encounter-cards', encounterCardRouter)
 app.use('/api/expeditions', expeditionsRouter)
 app.use('/api/game-state', gameStateRouter)
-app.use('/api/login', loginRouter)
+app.use('/api/user', userRouter)
 app.use('*', (req, res) => {
   res
     .status(404)

--- a/api-server/src/routes/user.ts
+++ b/api-server/src/routes/user.ts
@@ -17,25 +17,24 @@ type AsyncRequestHandler = (
 
 const router = express.Router()
 
-// TODO IMMEDIATELY remove. This is an example of an authenticated route
-router.get('/private-example', (async (req, res, next): Promise<void> => {
+// Get user data for logged-in user
+export const getUserDataHander: AsyncRequestHandler = async (
+  req,
+  res,
+  next
+) => {
   const { uid } = req.session
   if (uid !== undefined) {
     const user = await getUserByUid(uid)
     if (user !== null) {
-      res.send(`Hi ${user.username}. Your uid is ${uid}`)
+      return res.json({ username: user.username })
     }
-  } else {
-    res.sendStatus(401)
   }
-}) as RequestHandler)
 
-// TODO IMMEDIATELY REMOVE
-export const footestHandler: RequestHandler = (req, res, next) => {
-  const echo: string | undefined = req.body.echo
-  res.status(201).json({ result: 'yeah boi', echo })
+  res.sendStatus(401)
 }
-router.post('/footest', footestHandler)
+
+router.get('/', getUserDataHander as RequestHandler)
 
 // Create new user
 export const createUserHandler: AsyncRequestHandler = async (
@@ -63,7 +62,7 @@ export const createUserHandler: AsyncRequestHandler = async (
   }
 }
 
-router.post('/user', createUserHandler as RequestHandler)
+router.post('/', createUserHandler as RequestHandler)
 
 // Login existing user
 export const loginUserHandler: AsyncRequestHandler = async (req, res, next) => {

--- a/common/openapi-api.yaml
+++ b/common/openapi-api.yaml
@@ -127,7 +127,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ExpeditionUpdate'
-  /login/user:
+  /user:
+    get:
+      description: Get data about logged-in user
+      security: []
+      responses:
+        '200':
+          description: data about the user
+          content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserData'
+        '401':
+          description: Error. Not logged in.
     post:
       description: Create a new user
       security: []
@@ -144,12 +156,16 @@ paths:
           description: Error. User already exists
         '401':
           description: Error. Incorrect parameters.
-  /login/login:
+  /user/login:
     post:
       description: Log in an existing user account
       security: []
       requestBody:
-        $ref: '#/paths/~1login~1user/post/requestBody'
+        description: A username and password
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserLogin'
       responses:
         '200':
           description: Successful login, obtain a session cookie to be used in subsequent requests
@@ -409,6 +425,13 @@ components:
         password:
           type: string
       required: [username, password]
+
+    UserData:
+      type: object
+      properties:
+        username:
+          type: string
+      required: [username]
 
     # JSON Patch (RFC 6902)
     # Thanks to Jamie Tanna for the OpenAPI schema

--- a/common/src/openapi-api.d.ts
+++ b/common/src/openapi-api.d.ts
@@ -144,6 +144,19 @@ export interface paths {
     };
   };
   "/login/user": {
+    /** @description Get data about logged-in user */
+    get: {
+      responses: {
+        /** @description data about the user */
+        200: {
+          content: never;
+        };
+        /** @description Error. Not logged in. */
+        401: {
+          content: never;
+        };
+      };
+    };
     /** @description Create a new user */
     post: {
       /** @description A username and password */
@@ -310,6 +323,9 @@ export interface components {
     UserLogin: {
       username: string;
       password: string;
+    };
+    UserData: {
+      username: string;
     };
     PatchRequest: (components["schemas"]["JSONPatchRequestAddReplaceTest"] | components["schemas"]["JSONPatchRequestRemove"] | components["schemas"]["JSONPatchRequestMoveCopy"])[];
     JSONPatchRequestAddReplaceTest: {

--- a/common/src/openapiTypes/index.ts
+++ b/common/src/openapiTypes/index.ts
@@ -59,4 +59,6 @@ export type SkillCheckRoll = components['schemas']['SkillCheckRoll']
 
 export type StatNumber = components['schemas']['StatNumber']
 
+export type UserData = components['schemas']['UserData']
+
 export type UserLogin = components['schemas']['UserLogin']

--- a/website/README.md
+++ b/website/README.md
@@ -1,17 +1,5 @@
 # Developing
 
-## Local development standalone with Mirage server
-
-[Mirage JS](https://miragejs.com/) mocks the API calls, so you can
-
-`npm run mirage`
-
-The server runs on port 8081
-
 ## Local development with local API server
 
 See [top-level README](../README.md)
-
-# Known Issues
-
-- Mirage breaks hot reloading. See `mirage.ts`

--- a/website/package.json
+++ b/website/package.json
@@ -7,7 +7,6 @@
   "private": true,
   "scripts": {
     "dev": "next dev -p 8081",
-    "mirage": "cross-env NEXT_PUBLIC_USE_MIRAGE_SERVER=1 next dev -p 8081",
     "build": "next build",
     "start": "next start -p 8081",
     "check": "tsc --noEmit",
@@ -51,7 +50,6 @@
     "eslint-plugin-tailwindcss": "^3.13.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
-    "miragejs": "^0.1.48",
     "postcss": "^8",
     "prettier": "^3.1.1",
     "prettier-plugin-tailwindcss": "^0.5.9",

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -1,3 +1,6 @@
+import { ConnectedLoginOrCreate } from '../components/LoginForm'
+import { ConnectedPlayButton } from '../components/PlayButton'
+
 export default function Home(): React.ReactNode {
   return (
     <main className='flex min-h-screen flex-col items-center justify-between p-24'>
@@ -5,7 +8,8 @@ export default function Home(): React.ReactNode {
 
       <article>A post-postapocalyptic cooperative game</article>
 
-      <a href='/play'>PLAY</a>
+      <ConnectedLoginOrCreate />
+      <ConnectedPlayButton />
       <a href='/about'>About</a>
     </main>
   )

--- a/website/src/app/play/page.tsx
+++ b/website/src/app/play/page.tsx
@@ -19,19 +19,10 @@ import {
   useDispatch,
   useSelector
 } from '@/lib/redux'
-import { makeMirageServer } from '@/mirage'
 import { useBeginExpedition } from '@/lib/playerMoveHooks'
 import GameActiveEncounter from './GameActiveEncounter'
 import GameBetweenEncounters from './GameBetweenEncounters'
 import GameLoadout from './GameLoadout'
-
-console.log(`NODE_ENV: ${process.env.NODE_ENV}`)
-
-if (process.env.NEXT_PUBLIC_USE_MIRAGE_SERVER === '1') {
-  makeMirageServer({ environment: 'development' })
-} else {
-  console.log('NO MIRAGE')
-}
 
 export default function PlayPage(): React.ReactNode {
   const dispatch = useDispatch()

--- a/website/src/app/serverRoutes.ts
+++ b/website/src/app/serverRoutes.ts
@@ -11,3 +11,5 @@ export const drifterCardUrl = (drifterCardId: string): string =>
   `drifter-cards/${drifterCardId}`
 export const encounterCardUrl = (encounterCardId: string): string =>
   `encounter-cards/${encounterCardId}`
+export const userUrl = 'user'
+export const loginUrl = 'user/login'

--- a/website/src/components/LoginForm.tsx
+++ b/website/src/components/LoginForm.tsx
@@ -1,0 +1,222 @@
+'use client'
+import * as React from 'react'
+import {
+  useCreateUserMutation,
+  useGetUserDataQuery,
+  useLoginMutation
+} from '../lib/redux'
+import { type FetchBaseQueryError } from '@reduxjs/toolkit/query'
+import { type SerializedError } from '@reduxjs/toolkit'
+
+interface FieldProps extends React.ComponentProps<'input'> {
+  label: React.ReactNode
+  id: string
+}
+
+export function Field(props: FieldProps): React.ReactNode {
+  const { label, ...inputProps } = props
+  return (
+    <div className='mb-4'>
+      <label className='mb-1 block font-bold' htmlFor={inputProps.id}>
+        {label}
+      </label>
+      <input
+        {...inputProps}
+        className={
+          'rounded-lg border border-amber-500 bg-amber-900 p-2 focus:ring-amber-100'
+        }
+      />
+    </div>
+  )
+}
+
+interface LoginFormData {
+  username: string
+  password: string
+}
+
+type LoginFormType = 'CREATE_USER' | 'LOGIN'
+
+interface LoginFormProps {
+  handleFormSubmit: (data: LoginFormData) => void
+  formType: LoginFormType
+}
+
+function LoginForm(props: LoginFormProps): React.ReactNode {
+  const { handleFormSubmit } = props
+
+  let buttonText = ''
+  if (props.formType === 'CREATE_USER') {
+    buttonText = 'Create User'
+  } else if (props.formType === 'LOGIN') {
+    buttonText = 'Log In'
+  } else {
+    props.formType satisfies never
+    console.error('unhandled login formType: ', props.formType)
+  }
+
+  const submit = React.useCallback(
+    (e: React.FormEvent<HTMLFormElement>) => {
+      e.preventDefault()
+      const formData = new FormData(e.currentTarget)
+      const pojo = Object.fromEntries(formData)
+      if (
+        typeof pojo.username === 'string' &&
+        typeof pojo.password === 'string'
+      ) {
+        handleFormSubmit({
+          username: pojo.username,
+          password: pojo.password
+        })
+      } else {
+        console.error('invalid form input', pojo)
+      }
+    },
+    [handleFormSubmit]
+  )
+  return (
+    <form onSubmit={submit}>
+      <Field
+        autoComplete='username'
+        id={`${props.formType}-username`}
+        label='Username'
+        name='username'
+      />
+      <Field
+        autoComplete='password'
+        id={`${props.formType}-password`}
+        label='Password'
+        name='password'
+        type='password'
+      />
+      <button className='mt-2 w-full rounded-lg bg-amber-500 p-2 font-bold'>
+        {buttonText}
+      </button>
+    </form>
+  )
+}
+
+// TODO: less hacky implementation
+export function extractBaseQueryErrorMessage(
+  error: FetchBaseQueryError | SerializedError
+): string | null {
+  if (
+    typeof error === 'object' &&
+    error !== undefined &&
+    'status' in error &&
+    typeof error.data === 'object' &&
+    error.data !== null &&
+    'message' in error.data &&
+    typeof error.data.message === 'string'
+  ) {
+    return error.data.message
+  }
+  return null
+}
+
+export function ConnectedLoginForm(props: {
+  handleRegisterLinkClick: () => void
+}): React.ReactNode {
+  const [login, result] = useLoginMutation()
+
+  const errorComponent = result.isError ? (
+    <div className='text-xl font-bold italic text-amber-200'>
+      {extractBaseQueryErrorMessage(result.error) ?? '???'}
+    </div>
+  ) : null
+
+  return (
+    <article>
+      {errorComponent}
+      <LoginForm
+        formType='LOGIN'
+        handleFormSubmit={(data) => {
+          login(data).catch((err) => {
+            console.error('login mutation error', err)
+          })
+        }}
+      />
+      <div>
+        No account?{' '}
+        <a
+          href='#'
+          onClick={props.handleRegisterLinkClick}
+          className='font-bold text-amber-300 underline'
+        >
+          Register.
+        </a>
+      </div>
+    </article>
+  )
+}
+
+export function ConnectedCreateUserForm(props: {
+  handleCreateUser: () => void
+}): React.ReactNode {
+  const [createUser, result] = useCreateUserMutation()
+
+  const errorComponent = result.isError ? (
+    <div className='text-xl font-bold italic text-amber-200'>
+      {extractBaseQueryErrorMessage(result.error) ?? '???'}
+    </div>
+  ) : null
+
+  return (
+    <article>
+      <div className='text-center text-2xl'>Create new user</div>
+      {errorComponent}
+      <LoginForm
+        formType='CREATE_USER'
+        handleFormSubmit={(data) => {
+          createUser(data)
+            .then((response) => {
+              if (!('error' in response)) {
+                props.handleCreateUser()
+              }
+            })
+            .catch((err) => {
+              console.error('create user mutation error', err)
+            })
+        }}
+      />
+    </article>
+  )
+}
+
+export function LoadingLogin(): React.ReactNode {
+  return (
+    <div className='absolute left-0 top-0 z-40 flex h-full w-full items-center justify-center bg-slate-800/80'>
+      <span className='text-center'>loading...</span>
+    </div>
+  )
+}
+
+export function ConnectedLoginOrCreate(): React.ReactNode {
+  const { data, isFetching, isLoading } = useGetUserDataQuery()
+
+  const [showRegisterForm, setShowRegisterForm] = React.useState<boolean>(false)
+
+  const handleRegisterLinkClick = React.useCallback(() => {
+    setShowRegisterForm(true)
+  }, [])
+
+  if (data !== undefined && data !== null) {
+    return <div>{data.username}</div>
+  }
+
+  const form = showRegisterForm ? (
+    <ConnectedCreateUserForm
+      handleCreateUser={() => {
+        setShowRegisterForm(false)
+      }}
+    />
+  ) : (
+    <ConnectedLoginForm handleRegisterLinkClick={handleRegisterLinkClick} />
+  )
+  return (
+    <div className='relative p-8'>
+      {isLoading || isFetching ? <LoadingLogin /> : null}
+      {form}
+    </div>
+  )
+}

--- a/website/src/components/PlayButton.tsx
+++ b/website/src/components/PlayButton.tsx
@@ -1,0 +1,14 @@
+'use client'
+import * as React from 'react'
+import { useGetUserDataQuery } from '../lib/redux'
+
+export function ConnectedPlayButton(): React.ReactNode {
+  const { data, isFetching, isLoading } = useGetUserDataQuery()
+  if (isFetching || isLoading) {
+    return null
+  }
+  if (data === null || data === undefined) {
+    return null
+  }
+  return <a href='/play'>PLAY</a>
+}

--- a/website/src/lib/redux/slices/apiCacheSlice.ts
+++ b/website/src/lib/redux/slices/apiCacheSlice.ts
@@ -1,6 +1,14 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
-import { API_ROOT, drifterCardUrl, encounterCardUrl } from '@/app/serverRoutes'
 import {
+  API_ROOT,
+  drifterCardUrl,
+  encounterCardUrl,
+  loginUrl,
+  userUrl
+} from '@/app/serverRoutes'
+import {
+  type UserData,
+  type UserLogin,
   type DrifterCard,
   type EncounterCard
 } from '@solarpunk-drifters/common'
@@ -8,6 +16,7 @@ import {
 export const apiCacheSlice = createApi({
   reducerPath: 'apiCache',
   baseQuery: fetchBaseQuery({ baseUrl: API_ROOT }),
+  tagTypes: ['UserData'],
   endpoints: (builder) => ({
     getDrifterCard: builder.query<DrifterCard, string>({
       query: drifterCardUrl
@@ -36,9 +45,39 @@ export const apiCacheSlice = createApi({
     // }),
     getEncounterCard: builder.query<EncounterCard, string>({
       query: encounterCardUrl
+    }),
+
+    // USERS
+    // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+    getUserData: builder.query<UserData | null, void>({
+      query: () => userUrl,
+      providesTags: ['UserData']
+    }),
+    // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+    createUser: builder.mutation<void, UserLogin>({
+      query: (params: UserLogin) => ({
+        url: userUrl,
+        method: 'POST',
+        body: params
+      }),
+      invalidatesTags: ['UserData']
+    }),
+    // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+    login: builder.mutation<void, UserLogin>({
+      query: (params: UserLogin) => ({
+        url: loginUrl,
+        method: 'POST',
+        body: params
+      }),
+      invalidatesTags: ['UserData']
     })
   })
 })
 
-export const { useGetDrifterCardQuery, useGetEncounterCardQuery } =
-  apiCacheSlice
+export const {
+  useCreateUserMutation,
+  useGetDrifterCardQuery,
+  useGetEncounterCardQuery,
+  useGetUserDataQuery,
+  useLoginMutation
+} = apiCacheSlice

--- a/website/src/mirage.ts
+++ b/website/src/mirage.ts
@@ -1,3 +1,4 @@
+// TODO: delete this file. Mirage is no longer used.
 import { type Server, createServer, Response } from 'miragejs'
 import {
   ACTIVE_ENCOUNTER,
@@ -149,6 +150,16 @@ export function makeMirageServer({ environment = 'test' }): Server {
           clientEvents
         }
         return new Response(200, undefined, res)
+      })
+
+      this.get('/user', (schema, request) => {
+        return new Response(200, undefined, { username: 'mirageTestUser' })
+      })
+      this.post('/user', (schema, request) => {
+        const body = request.requestBody
+        console.log('/user POST', body)
+        // TODO
+        return new Response(500, undefined, 'TODO NOT IMPLEMENTED')
       })
 
       // TODO: this doesn't fix the problem with Webpack HMR via Next


### PR DESCRIPTION
- API: rename and modify /user routes (formerly /login)
- api-server: add GET /user route to provide FE with data for logged-in user
- Allow user to create user and login from website
- Remove Mirage, too much trouble now that api server exists, doesn't play well with nextjs App Router without workarounds: https://github.com/miragejs/miragejs/issues/1088